### PR TITLE
OS X crashing bug fix

### DIFF
--- a/model_brush.c
+++ b/model_brush.c
@@ -4595,10 +4595,10 @@ static void Mod_Q3BSP_LoadTextures(lump_t *l)
 
 	for (i = 0;i < count;i++)
 	{
-		strlcpy (out[i].name, in[i].name, sizeof (out[i].name));
+		
 		out[i].surfaceflags = LittleLong(in[i].surfaceflags);
 		out[i].supercontents = Mod_Q3BSP_SuperContentsFromNativeContents(loadmodel, LittleLong(in[i].contents));
-		Mod_LoadTextureFromQ3Shader(out + i, out[i].name, true, true, TEXF_MIPMAP | TEXF_ISWORLD | TEXF_PICMIP | TEXF_COMPRESS);
+		Mod_LoadTextureFromQ3Shader(out + i, in[i].name, true, true, TEXF_MIPMAP | TEXF_ISWORLD | TEXF_PICMIP | TEXF_COMPRESS);
 		// restore the surfaceflags and supercontents
 		out[i].surfaceflags = LittleLong(in[i].surfaceflags);
 		out[i].supercontents = Mod_Q3BSP_SuperContentsFromNativeContents(loadmodel, LittleLong(in[i].contents));

--- a/sv_main.c
+++ b/sv_main.c
@@ -2459,7 +2459,10 @@ static void SV_UpdateToReliableMessages (void)
 		if (name == NULL)
 			name = "";
 		// always point the string back at host_client->name to keep it safe
-		strlcpy (host_client->name, name, sizeof (host_client->name));
+		//strlcpy (host_client->name, name, sizeof (host_client->name));
+ 	
+		if (name != host_client->name) // prevent buffer overlap SIGABRT on Mac OSX
+ 			strlcpy (host_client->name, name, sizeof (host_client->name));
 		PRVM_serveredictstring(host_client->edict, netname) = PRVM_SetEngineString(prog, host_client->name);
 		if (strcmp(host_client->old_name, host_client->name))
 		{
@@ -2489,7 +2492,9 @@ static void SV_UpdateToReliableMessages (void)
 		if (model == NULL)
 			model = "";
 		// always point the string back at host_client->name to keep it safe
-		strlcpy (host_client->playermodel, model, sizeof (host_client->playermodel));
+		//strlcpy (host_client->playermodel, model, sizeof (host_client->playermodel));
+		if (model != host_client->playermodel) // prevent buffer overlap SIGABRT on Mac OSX
+ 			strlcpy (host_client->playermodel, model, sizeof (host_client->playermodel));
 		PRVM_serveredictstring(host_client->edict, playermodel) = PRVM_SetEngineString(prog, host_client->playermodel);
 
 		// NEXUIZ_PLAYERSKIN
@@ -2497,7 +2502,9 @@ static void SV_UpdateToReliableMessages (void)
 		if (skin == NULL)
 			skin = "";
 		// always point the string back at host_client->name to keep it safe
-		strlcpy (host_client->playerskin, skin, sizeof (host_client->playerskin));
+		//strlcpy (host_client->playerskin, skin, sizeof (host_client->playerskin));
+		if (skin != host_client->playerskin) // prevent buffer overlap SIGABRT on Mac OSX
+			strlcpy (host_client->playerskin, skin, sizeof (host_client->playerskin));
 		PRVM_serveredictstring(host_client->edict, playerskin) = PRVM_SetEngineString(prog, host_client->playerskin);
 
 		// TODO: add an extension name for this [1/17/2008 Black]

--- a/vid_sdl.c
+++ b/vid_sdl.c
@@ -793,17 +793,19 @@ void Sys_SendKeyEvents( void )
 			case SDL_VIDEOEXPOSE:
 				break;
 			case SDL_VIDEORESIZE:
-				if(vid_resizable.integer < 2)
+				if(vid_resizable.integer < 2 || vid_isfullscreen)
 				{
 					vid.width = event.resize.w;
 					vid.height = event.resize.h;
-					screen = SDL_SetVideoMode(vid.width, vid.height, video_bpp, video_flags);
+					if (!vid_isfullscreen)
+						screen = SDL_SetVideoMode(vid.width, vid.height, video_bpp, video_flags);
+
 					if (vid_softsurface)
 					{
 						SDL_FreeSurface(vid_softsurface);
 						vid_softsurface = SDL_CreateRGBSurface(SDL_SWSURFACE, vid.width, vid.height, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
-						vid.softpixels = (unsigned int *)vid_softsurface->pixels;
 						SDL_SetAlpha(vid_softsurface, 0, 255);
+						vid.softpixels = (unsigned int *)vid_softsurface->pixels;
 						if (vid.softdepthpixels)
 							free(vid.softdepthpixels);
 						vid.softdepthpixels = (unsigned int*)calloc(1, vid.width * vid.height * 4);


### PR DESCRIPTION
Stupid OS X enforced a strlcpy buffer overlap source/dest so I modified it. Only "bugs" with OS X still are video resizing can have a blank screen that can be fixed with a vid_restart. The other bug is that is doesn't know where to look for textures/sounds. 