### PR TITLE
Adding utf8_oldfont_for_oldchars cvar for force use old style rendering for characters from 0x80 to 0xFF

### DIFF
--- a/utf8lib.c
+++ b/utf8lib.c
@@ -8,10 +8,12 @@ Initialization of UTF-8 support and new cvars.
 */
 // for compatibility this defaults to 0
 cvar_t    utf8_enable = {CVAR_SAVE, "utf8_enable", "0", "Enable UTF-8 support. For compatibility, this is disabled by default in most games."};
+cvar_t    utf8_oldfont_for_oldchars = {CVAR_SAVE, "utf8_oldfont_for_oldchars", "1", "Use old font for standart 8bit characters"};
 
 void   u8_Init(void)
 {
 	Cvar_RegisterVariable(&utf8_enable);
+	Cvar_RegisterVariable(&utf8_oldfont_for_oldchars);
 }
 
 /*
@@ -181,8 +183,10 @@ findchar:
 		*_start = i;
 	if (_len)
 		*_len = bits;
-	if (_ch)
+	if (_ch) {
 		*_ch = ch;
+		if (utf8_oldfont_for_oldchars.integer && ch < 256) *_ch |= 0xE000;
+	}
 	//fprintf(stderr, "valid utf8\n");
 	return true;
 }


### PR DESCRIPTION
всякие дополнительные символы не работают, если включен utf8 и используется юникодный шрифт, поскольку эти символы пытаются отрисоваться через шрифт, где на их месте находятся другие символы. теоретически эта опция может перекрывать какие-то полезные юникодные символы, но на первый взгляд там ничего полезного нет.